### PR TITLE
now with tls goodness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+ssl/
+bin/
+
 # Binaries for programs and plugins
 echo-api
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,24 @@
 .DEFAULT_GOAL := all
+.PHONY: all test-build lint test start run clean-certs
 
 BIN_FILE=bin/echo-api
 
 build:
 	go build -o ${BIN_FILE} main.go handlers.go
 
-run: 
+create-certs:
+	mkdir --parents ssl && \
+	openssl req -subj '/CN=example.com/O=echo-api/C=US' -new -newkey rsa:2048 -sha256 -days 365 -nodes -x509 -keyout ssl/server.key -out ssl/server.crt
+
+clean-certs:
+	test -d ssl && rm --recursive --force ssl
+
+recreate-certs: clean-certs create-certs
+
+run: create-certs
 	go run .
 
-start: build
+start: create-certs build
 	./${BIN_FILE}
 
 test:
@@ -18,7 +28,7 @@ lint:
 	golint
 
 clean:
-	test -f ${BIN_FILE} && rm ${BIN_FILE}
+	test -d bin && rm --recursive --force bin 
 
 test-build: test build
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple api server that echoes back whatever string a client sent through an AP
 Post `application/x-www-form-urlencoded` data to the endpoint with a key of `echo` and any string for the value, and you will get a response of the value posted.
 
 ```
-❯ curl localhost:8080/ -d "echo=hello"                                                                                             ─╯
+❯ curl https://localhost:8443/ --insecure --data "echo=hello" 
 hello
 ```
 
@@ -21,18 +21,18 @@ hello
 
 ```
 ❯ ./echo-api
-2021/01/30 15:58:55 Creating server at localhost:8080...
+2021/01/30 15:58:55 Creating server at localhost:8443...
 ```
 
 
 To make requests, you can do some thing like this:
 ```
-❯ curl localhost:8080 -d "echo=hello" 
+❯ curl https://localhost:8443/ --insecure --data "echo=hello"
 ```
 
 You can also hit the `healthz` endpoint
 ```
-❯ curl localhost:8080/healthz                                                                                                      ─╯
+❯ curl https://localhost:8443/healthz --insecure
 OK
 ```
 
@@ -53,12 +53,34 @@ ok  	_/home/greco/src/drgreco/echo-api	0.003s
 
 Additional testing can be found [here](testing/README.md)
 
+### Makefile targets
+
+`Makefile` options:
+| argument       | description |
+|----------------|----------------|
+| build          | creates executable at `bin/echo-api`         |
+| create-certs   | creates certificates for testing in `ssl/`   |
+| clean-certs    | deletes directory `ssl/`                     |
+| recreate-certs | runs `clean-certs` then `create-certs`       |
+| run            | runs without creating executable: `go run .` |
+| start          | runs `build`, then executes `bin/echo-api`   |
+| test           | runs tests: `go test -cover -tags test `     |
+| lint           | runs golint                                  |
+| clean          | deletes directory `bin/`                     |
+| test-build     | runs the arguments `test` then `build`       |
+| all            | runs the arguments `test-build` then `start  |
+
+
+Defaults to `all`
+
 #### Configuration
 
 echo-api accepts three different environment variables
  - `ECHO_HOST` for the ip to listen on. defaults to `localhost`
- - `ECHO_PORT` for the port to listen on. defaults to `8080`
+ - `ECHO_PORT` for the port to listen on. defaults to `8443`
  - `ECHO_HEALTHCHECK` where to listen for a healthcheck. requires leading `/`. defaults to `/healthz`
+ - `ECHO_SERVERPRIVATEKEY` path to tls private key. defaults to `ssl/server.key`
+ - `ECHO_SERVERCERTIFICATE` path to tls certificate. defaults to `ssl/server.crt`
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Additional testing can be found [here](testing/README.md)
 
 ### Makefile targets
 
-`Makefile` options:
+`Makefile` targets:
 | argument       | description |
 |----------------|----------------|
 | build          | creates executable at `bin/echo-api`         |
@@ -81,6 +81,7 @@ echo-api accepts three different environment variables
  - `ECHO_HEALTHCHECK` where to listen for a healthcheck. requires leading `/`. defaults to `/healthz`
  - `ECHO_SERVERPRIVATEKEY` path to tls private key. defaults to `ssl/server.key`
  - `ECHO_SERVERCERTIFICATE` path to tls certificate. defaults to `ssl/server.crt`
+ - `ECHO_TLS_DISABLE` disables TLS. Only accepts strings `true` or `false`. defaults to `false`.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -91,5 +91,5 @@ echo-api accepts three different environment variables
 
   - [x] makefile to easily build and demonstrate your server capabilities
   - [x] Documentation
-  - [ ] SSL
+  - [x] SSL
   - [ ] authentication

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ func config() (map[string]string) {
     config["HealthCheck"]       = "/healthz"
     config["ServerPrivateKey"]  = "ssl/server.key"
     config["ServerCertificate"] = "ssl/server.crt"
+    config["TlsDisable"]        = "false"
 
     // get env variables if set
     Host, ok := os.LookupEnv("ECHO_HOST")
@@ -33,6 +34,9 @@ func config() (map[string]string) {
     ServerCertificate, ok := os.LookupEnv("ECHO_SERVERCERTIFICATE")
     if ok { config["ServerCertificate"] = ServerCertificate }
 
+    TlsDisable, ok := os.LookupEnv("ECHO_TLS_DISABLE")
+    if ok { config["TlsDisable"] = TlsDisable}
+
     return config
 }
 
@@ -44,6 +48,12 @@ func main () {
     http.HandleFunc(config["HealthCheck"], healthCheckHandler)
 
     // launch http listener
-    log.Printf("Creating server at %s:%s...", config["Host"], config["Port"])
-    log.Fatal(http.ListenAndServeTLS(config["Host"]+":"+config["Port"], config["ServerCertificate"], config["ServerPrivateKey"], nil))
+    // check if we want TLS or not
+    if config["TlsDisable"] == "true" {
+        log.Printf("Creating http server at %s:%s...", config["Host"], config["Port"])
+        log.Fatal(http.ListenAndServe(config["Host"]+":"+config["Port"], nil))
+    } else {
+        log.Printf("Creating TLS server at %s:%s...", config["Host"], config["Port"])
+        log.Fatal(http.ListenAndServeTLS(config["Host"]+":"+config["Port"], config["ServerCertificate"], config["ServerPrivateKey"], nil))
+    }
 }

--- a/testing/README.md
+++ b/testing/README.md
@@ -3,7 +3,7 @@
 Using `ab` from the [apache-tools](http://httpd.apache.org/docs/2.4/programs/ab.html) package
 
 ```
-ab -c 100 -n 1000 -T application/x-www-form-urlencoded -p ab-test.txt http://localhost:8080/
+ab -c 100 -n 1000 -T application/x-www-form-urlencoded -p ab-test.txt https://localhost:8443/
 ```
 
 Where:
@@ -11,4 +11,4 @@ Where:
  - `-n` is the total number of requests
  - `-T application/x-www-form-urlencoded` is content-type
  - `-p` points to the file `ab-test.txt` in this directory for an echo value
- - `http://localhost:8080` the url for where `echo-api` is running
+ - `https://localhost:8443` the url for where `echo-api` is running


### PR DESCRIPTION
 - Use the makefile to create ssl certs
 - TLS is now default (new env flag to disable)
 - Updates to documentation/cleanup

Updated `Makefile` targets
| argument       | description |
|----------------|----------------|
| create-certs   | creates certificates for testing in ssl/   |
| clean-certs    | deletes directory ssl/                     |
| recreate-certs | runs clean-certs then create-certs       |
