### PR TITLE
adding basic authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 BIN_FILE=bin/echo-api
 
 build:
-	go build -o ${BIN_FILE} main.go handlers.go
+	go build -o ${BIN_FILE} main.go handlers.go 
 
 create-certs:
 	mkdir --parents ssl && \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 BIN_FILE=bin/echo-api
 
 build:
-	go build -o ${BIN_FILE} main.go handlers.go 
+	go build -o ${BIN_FILE} main.go handlers.go
 
 create-certs:
 	mkdir --parents ssl && \

--- a/README.md
+++ b/README.md
@@ -7,9 +7,17 @@ A simple api server that echoes back whatever string a client sent through an AP
 Post `application/x-www-form-urlencoded` data to the endpoint with a key of `echo` and any string for the value, and you will get a response of the value posted.
 
 ```
-❯ curl https://localhost:8443/ --insecure --data "echo=hello" 
+❯ curl https://localhost:8443/ --insecure --user "user:test" --data "echo=hello" 
 hello
 ```
+
+You can also hit the `healthz` endpoint
+```
+❯ curl https://localhost:8443/healthz --insecure
+OK
+```
+
+Note that the `healthz` endpoint does not require basic auth.
 
 ### Build
 
@@ -24,19 +32,7 @@ hello
 2021/01/30 15:58:55 Creating server at localhost:8443...
 ```
 
-
-To make requests, you can do some thing like this:
-```
-❯ curl https://localhost:8443/ --insecure --data "echo=hello"
-```
-
-You can also hit the `healthz` endpoint
-```
-❯ curl https://localhost:8443/healthz --insecure
-OK
-```
-
-### Testing Changes
+## Testing Changes
 
 Run `go test`
 
@@ -82,6 +78,17 @@ echo-api accepts three different environment variables
  - `ECHO_SERVERPRIVATEKEY` path to tls private key. defaults to `ssl/server.key`
  - `ECHO_SERVERCERTIFICATE` path to tls certificate. defaults to `ssl/server.crt`
  - `ECHO_TLS_DISABLE` disables TLS. Only accepts strings `true` or `false`. defaults to `false`.
+ - `ECHO_BASIC_AUTH_FILE` file to find basic auth information. defaults to `auth.db`.
+
+#### Basic Auth
+
+Basic Auth is handled by default in a file named `auth.db`. This file looks like this:
+```
+user:dGVzdA==
+bob:bGV0bWVpbg==
+```
+
+The format is `[user]:[base64encoded password]
 
 ## Features
 
@@ -93,4 +100,4 @@ echo-api accepts three different environment variables
   - [x] makefile to easily build and demonstrate your server capabilities
   - [x] Documentation
   - [x] SSL
-  - [ ] authentication
+  - [x] authentication

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Note that the `healthz` endpoint does not require basic auth.
 2021/01/30 15:58:55 Creating server at localhost:8443...
 ```
 
-## Testing Changes
+### Testing Changes
 
 Run `go test`
 

--- a/auth.db
+++ b/auth.db
@@ -1,0 +1,2 @@
+user:dGVzdA==
+bob:bGV0bWVpbg==

--- a/main.go
+++ b/main.go
@@ -3,20 +3,25 @@
 package main
 
 import (
+    "bufio"
     "log"
     "net/http"
     "os"
+    "strings"
 )
 
+var BasicAuthData = make(map[string]string)
+
 // initialize some default configuration for net/http
-func config() (map[string]string) {
+func config() map[string]string {
     config := make(map[string]string)
     config["Host"]              = "localhost"
     config["Port"]              = "8443"
     config["HealthCheck"]       = "/healthz"
     config["ServerPrivateKey"]  = "ssl/server.key"
     config["ServerCertificate"] = "ssl/server.crt"
-    config["TlsDisable"]        = "false"
+    config["TLSDisable"]        = "false"
+    config["BasicAuthFile"]     = "auth.db"
 
     // get env variables if set
     Host, ok := os.LookupEnv("ECHO_HOST")
@@ -34,10 +39,38 @@ func config() (map[string]string) {
     ServerCertificate, ok := os.LookupEnv("ECHO_SERVERCERTIFICATE")
     if ok { config["ServerCertificate"] = ServerCertificate }
 
-    TlsDisable, ok := os.LookupEnv("ECHO_TLS_DISABLE")
-    if ok { config["TlsDisable"] = TlsDisable}
+    TLSDisable, ok := os.LookupEnv("ECHO_TLS_DISABLE")
+    if ok { config["TLSDisable"] = TLSDisable }
+
+    BasicAuthFile, ok := os.LookupEnv("ECHO_BASIC_AUTH_FILE")
+    if ok { config["BasicAuthFile"] = BasicAuthFile }
+
+    // Set BasicAuthData
+    BasicAuthData = readBasicAuthData(config["BasicAuthFile"])
 
     return config
+}
+
+// Read basic auth file, return map
+func readBasicAuthData(BasicAuthFile string) map[string]string {
+    // read basic auth file
+    // else error out if the basic auth file is not readable
+    log.Printf("reading basic auth file: %s", BasicAuthFile)
+    file, err := os.Open(BasicAuthFile)
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer file.Close()
+
+    data := make(map[string]string)
+    scanner := bufio.NewScanner(file)
+    for scanner.Scan() {
+        lineSplits := strings.Split(scanner.Text(), ":")
+        data[lineSplits[0]] = strings.Join(lineSplits[1:], "")
+        log.Printf("adding basic auth for user: %v", lineSplits[0])
+    }
+
+    return data
 }
 
 func main () {
@@ -49,7 +82,7 @@ func main () {
 
     // launch http listener
     // check if we want TLS or not
-    if config["TlsDisable"] == "true" {
+    if config["TLSDisable"] == "true" {
         log.Printf("Creating http server at %s:%s...", config["Host"], config["Port"])
         log.Fatal(http.ListenAndServe(config["Host"]+":"+config["Port"], nil))
     } else {


### PR DESCRIPTION
#### Basic Auth

Basic Auth is handled by default in a file named `auth.db`. This file looks like this:
```
user:dGVzdA==
bob:bGV0bWVpbg==
```

The format is `[user]:[base64encoded password]

This PR also includes updating tests and other doc cleanup
